### PR TITLE
docs/JT-2 게시글 등록 API 명세서 작성

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,20 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+= Practice Project Api Specification
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:author: cupid
+:email: cupid@soma.com
+
+== 1. 게시글
+=== 1.1. 저장
+==== 성공
+.request
+include::{snippets}/create-post-success/http-request.adoc[]
+
+.response
+include::{snippets}/create-post-success/http-response.adoc[]

--- a/backend/src/main/java/com/cupid/backend/post/controller/PostController.java
+++ b/backend/src/main/java/com/cupid/backend/post/controller/PostController.java
@@ -1,0 +1,24 @@
+package com.cupid.backend.post.controller;
+
+import com.cupid.backend.post.controller.dto.PostRequest;
+import com.cupid.backend.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody PostRequest postRequest) {
+        postService.create(postRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/cupid/backend/post/controller/dto/PostRequest.java
+++ b/backend/src/main/java/com/cupid/backend/post/controller/dto/PostRequest.java
@@ -1,0 +1,14 @@
+package com.cupid.backend.post.controller.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostRequest {
+
+    private String title;
+    private String content;
+    private String author;
+}

--- a/backend/src/main/java/com/cupid/backend/post/service/PostService.java
+++ b/backend/src/main/java/com/cupid/backend/post/service/PostService.java
@@ -1,0 +1,11 @@
+package com.cupid.backend.post.service;
+
+import com.cupid.backend.post.controller.dto.PostRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostService {
+
+    public void create(PostRequest postRequest) {
+    }
+}

--- a/backend/src/test/java/com/cupid/backend/ApiDocument.java
+++ b/backend/src/test/java/com/cupid/backend/ApiDocument.java
@@ -1,0 +1,53 @@
+package com.cupid.backend;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@EnableMockMvc
+@AutoConfigureRestDocs
+public class ApiDocument {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    protected RestDocumentationResultHandler toDocument(String title) {
+        return document(title, getDocumentRequest(), getDocumentResponse());
+    }
+
+    protected String toJson(Object object) {
+        try {
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("직렬화 오류");
+        }
+    }
+
+    private OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                modifyUris()
+                        .scheme("http")
+                        .host("jikting")
+                        .removePort(),
+                prettyPrint());
+    }
+
+    private OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+}

--- a/backend/src/test/java/com/cupid/backend/EnableMockMvc.java
+++ b/backend/src/test/java/com/cupid/backend/EnableMockMvc.java
@@ -1,0 +1,23 @@
+package com.cupid.backend;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AutoConfigureMockMvc
+@Import(EnableMockMvc.Config.class)
+public @interface EnableMockMvc {
+
+    class Config {
+        @Bean
+        public CharacterEncodingFilter characterEncodingFilter() {
+            return new CharacterEncodingFilter("UTF-8", true);
+        }
+    }
+}

--- a/backend/src/test/java/com/cupid/backend/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/cupid/backend/post/controller/PostControllerTest.java
@@ -1,4 +1,57 @@
 package com.cupid.backend.post.controller;
 
-public class PostControllerTest {
+import com.cupid.backend.ApiDocument;
+import com.cupid.backend.post.controller.dto.PostRequest;
+import com.cupid.backend.post.service.PostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+public class PostControllerTest extends ApiDocument {
+
+    private PostRequest postRequest;
+
+    @MockBean
+    private PostService postService;
+
+    @BeforeEach
+    void setUp() {
+        postRequest = PostRequest.builder()
+                .title("제목")
+                .content("본문")
+                .author("작성자")
+                .build();
+    }
+
+    @Test
+    void 게시글_저장_성공() throws Exception {
+        // given
+        willDoNothing().given(postService).create(any(PostRequest.class));
+        // when
+        ResultActions resultActions = 게시글_저장_요청();
+        // then
+        게시글_저장_요청_성공(resultActions);
+    }
+
+    private ResultActions 게시글_저장_요청() throws Exception {
+        return mockMvc.perform(post("/api/v1/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(postRequest)));
+    }
+
+    private ResultActions 게시글_저장_요청_성공(ResultActions resultActions) throws Exception {
+        return resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(toDocument("create-post-success"));
+    }
 }

--- a/backend/src/test/java/com/cupid/backend/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/cupid/backend/post/controller/PostControllerTest.java
@@ -1,0 +1,4 @@
+package com.cupid.backend.post.controller;
+
+public class PostControllerTest {
+}


### PR DESCRIPTION
## Jira Issue
[JT-2](https://soma-cupid.atlassian.net/browse/JT-2?atlOrigin=eyJpIjoiZDgzM2IyMmJlNmZmNGZlZWE3ZmI3MWY2MjE2YmJhZTciLCJwIjoiaiJ9)

## 요구사항

- [x] 게시글 등록 API 명세서 작성

## 변경사항

- `@EnableMockMvc` 추가
- 문서화 공통 로직 포함된 `ApiDocument` 추가
- `PostControllerTest` 추가
- `PostController` 추가
- `PostService` 추가
- `PostRequest` 추가
- API 문서화를 위한 asciidoctor 파일 `index` 추가

## 리뷰 우선순위

🙂 보통

[JT-2]: https://soma-cupid.atlassian.net/browse/JT-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ