### PR TITLE
docs/JT-8 회원 등록 API 명세서 작성

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -18,3 +18,12 @@ include::{snippets}/create-post-success/http-request.adoc[]
 
 .response
 include::{snippets}/create-post-success/http-response.adoc[]
+
+== 2. 게시글
+=== 2.1. 저장
+==== 성공
+.request
+include::{snippets}/create-member-success/http-request.adoc[]
+
+.response
+include::{snippets}/create-member-success/http-response.adoc[]

--- a/backend/src/main/java/com/cupid/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cupid/backend/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.cupid.backend.member.controller;
+
+import com.cupid.backend.post.controller.dto.PostRequest;
+import com.cupid.backend.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody MemberRequest memberRequest) {
+        memberService.create(memebrRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/cupid/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cupid/backend/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.cupid.backend.member.controller;
 
+import com.cupid.backend.member.controller.dto.SignUpRequest;
+import com.cupid.backend.member.service.MemberService;
 import com.cupid.backend.post.controller.dto.PostRequest;
 import com.cupid.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +19,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody MemberRequest memberRequest) {
-        memberService.create(memebrRequest);
+    public ResponseEntity<Void> create(@RequestBody SignUpRequest signUpRequest) {
+        memberService.create(signUpRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/cupid/backend/member/controller/dto/SignUpRequest.java
+++ b/backend/src/main/java/com/cupid/backend/member/controller/dto/SignUpRequest.java
@@ -1,0 +1,15 @@
+package com.cupid.backend.member.controller.dto;
+
+import com.sun.istack.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpRequest {
+
+    private String name;
+    private int age;
+    private String email;
+}

--- a/backend/src/main/java/com/cupid/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/cupid/backend/member/service/MemberService.java
@@ -1,0 +1,12 @@
+package com.cupid.backend.member.service;
+
+import com.cupid.backend.member.controller.dto.SignUpRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    public void create(SignUpRequest signUpRequest) {
+
+    }
+}

--- a/backend/src/main/java/com/cupid/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/cupid/backend/member/service/MemberService.java
@@ -7,6 +7,5 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     public void create(SignUpRequest signUpRequest) {
-
     }
 }

--- a/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
@@ -1,0 +1,53 @@
+package com.cupid.backend.member.controller;
+
+import com.cupid.backend.post.controller.dto.PostRequest;
+import com.cupid.backend.post.service.PostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest {
+
+    private SignUpRequest signUpRequest;
+
+    @MockBean
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        signUpRequest = SignUpRequest.builder()
+                .build();
+    }
+
+    @Test
+    void 회원가입_성공() throws Exception {
+        // given
+        willDoNothing().given(signUpRequest).create(any(SignUpRequest.class));
+        // when
+        ResultActions resultActions = 회원가입_요청();
+        // then
+        회원가입_요청_성공(resultActions);
+    }
+
+    private ResultActions 회원가입_요청() throws Exception {
+        return mockMvc.perform(post("/api/v1/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(postRequest)));
+    }
+
+    private ResultActions 회원가입_요청_성공(ResultActions resultActions) throws Exception {
+        return resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(toDocument("create-post-success"));
+    }
+}

--- a/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
@@ -1,7 +1,8 @@
 package com.cupid.backend.member.controller;
 
-import com.cupid.backend.post.controller.dto.PostRequest;
-import com.cupid.backend.post.service.PostService;
+import com.cupid.backend.ApiDocument;
+import com.cupid.backend.member.controller.dto.SignUpRequest;
+import com.cupid.backend.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -16,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
-public class MemberControllerTest {
+public class MemberControllerTest extends ApiDocument {
 
     private SignUpRequest signUpRequest;
 
@@ -32,7 +33,7 @@ public class MemberControllerTest {
     @Test
     void 회원가입_성공() throws Exception {
         // given
-        willDoNothing().given(signUpRequest).create(any(SignUpRequest.class));
+        willDoNothing().given(memberService).create(any(SignUpRequest.class));
         // when
         ResultActions resultActions = 회원가입_요청();
         // then
@@ -40,14 +41,14 @@ public class MemberControllerTest {
     }
 
     private ResultActions 회원가입_요청() throws Exception {
-        return mockMvc.perform(post("/api/v1/posts")
+        return mockMvc.perform(post("/api/v1/members")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(postRequest)));
+                .content(toJson(signUpRequest)));
     }
 
     private ResultActions 회원가입_요청_성공(ResultActions resultActions) throws Exception {
         return resultActions.andExpect(status().isOk())
                 .andDo(print())
-                .andDo(toDocument("create-post-success"));
+                .andDo(toDocument("create-member-success"));
     }
 }

--- a/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/cupid/backend/member/controller/MemberControllerTest.java
@@ -27,6 +27,9 @@ public class MemberControllerTest extends ApiDocument {
     @BeforeEach
     void setUp() {
         signUpRequest = SignUpRequest.builder()
+                .name("최용태")
+                .age(27)
+                .email("test@test.com")
                 .build();
     }
 


### PR DESCRIPTION
## 요구사항

- [x] 회원 등록 API 명세서 작성

## 변경사항

- `MemberControllerTest` 추가
- `MemberController` 추가
- `MemberService` 추가
- `SignUpRequest` 추가
- `index.adoc`에 회원 등록  문서 추가

## 리뷰 우선순위
🙂 보통